### PR TITLE
Consider environment defined on explicit set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,13 @@ function dget() {
  */
 function dset(val) {
   var value = '' + this.value;
+
   if(this(val)) {
     process.env.NODE_ENV = val;
     this.current = val;
+    // considered defined the first time the setter
+    // is called explicitly
+    this.defined = true;
     return function revert() {
       process.env.NODE_ENV = value;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nenv",
   "description": "Node development environment manager",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "muji <noop@xpm.io>",
   "main": "lib/index.js",
   "license": "MIT",


### PR DESCRIPTION
Prevents a bug with testing against `env.defined` after an environment has been explicitly set.